### PR TITLE
add visual model config for llava-next-video

### DIFF
--- a/src/llamafactory/model/loader.py
+++ b/src/llamafactory/model/loader.py
@@ -115,8 +115,8 @@ def load_config(model_args: "ModelArguments") -> "PretrainedConfig":
     """
     init_kwargs = _get_init_kwargs(model_args)
     if "LLaVA-NeXT-Video" in model_args.model_name_or_path:
+        from transformers import PretrainedConfig, LlavaNextVideoConfig, CLIPVisionConfig, LlamaConfig
         official_config = PretrainedConfig.from_pretrained(model_args.model_name_or_path, **init_kwargs)
-        from transformers import LlavaNextVideoConfig, CLIPVisionConfig, LlamaConfig
         config = LlavaNextVideoConfig(CLIPVisionConfig(**official_config.vision_config), LlamaConfig(**official_config.text_config))
         setattr(config, "visual_inputs", True)
         return config

--- a/src/llamafactory/model/model_utils/visual.py
+++ b/src/llamafactory/model/model_utils/visual.py
@@ -95,7 +95,7 @@ def autocast_projector_dtype(
 
 
 def configure_visual_model(config: "PretrainedConfig") -> None:
-    if getattr(config, "model_type", None) in ["llava", "llava_next", "video_llava", "idefics2"]:  # required for ds zero3 and valuehead models
+    if getattr(config, "model_type", None) in ["llava", "llava_next", "video_llava", "idefics2", "llava_next_video"]:  # required for ds zero3 and valuehead models
         setattr(config, "hidden_size", getattr(config.text_config, "hidden_size", None))
 
     if getattr(config, "is_yi_vl_derived_model", None):


### PR DESCRIPTION
# What does this PR do?
Solve the problem that `llava_next_video` model doesn't start properly with deepspeed `zero3-stage` during full training
Fixes # (issue)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
